### PR TITLE
Specify enum for _If

### DIFF
--- a/src/Cseq.cpp
+++ b/src/Cseq.cpp
@@ -144,7 +144,7 @@ bool Cseq::Convert()
 
 		if (statusByte == 0xA2)
 		{
-			cmd.Suffix3 = _If;
+			cmd.Suffix3 = SuffixType::_If;
 
 			statusByte = ReadFixLen(pos, 1);
 		}


### PR DESCRIPTION
When I tried building caesar, I got an error about `_If` being ambiguous. On clang for MacOS, at least, `_If` is defined in the `type_traits` header. This should fix that.